### PR TITLE
feat: do not check limit correctness explicitly while reading

### DIFF
--- a/src/hstreamdb.erl
+++ b/src/hstreamdb.erl
@@ -70,19 +70,10 @@
 -type shard_id() :: hstreamdb_client:shard_id().
 -type hrecord() :: hstreamdb_client:hrecord().
 
--type limits_shard() :: hstreamdb_client:limits_shard().
 -type limits_key() :: hstreamdb_client:limits_key().
 
 -type reader_fold_acc() :: hstreamdb_client:reader_fold_acc().
 -type reader_fold_fun() :: hstreamdb_client:reader_fold_fun().
-
--define(DEFAULT_READ_SINGLE_SHARD_STREAM_OPTS, #{
-    limits => #{
-        from => #{offset => {specialOffset, 0}},
-        until => #{offset => {specialOffset, 1}},
-        maxReadBatches => 0
-    }
-}).
 
 %%--------------------------------------------------------------------
 %% Client facade

--- a/test/hstreamdb_read_SUITE.erl
+++ b/test/hstreamdb_read_SUITE.erl
@@ -74,7 +74,7 @@ t_read_stream_key(Config) ->
     },
 
     ?assertMatch(
-        {error, {shard_mismatch, {_, 123}}},
+        {error, {shard_mismatch, _}},
         hstreamdb:read_stream_key(Reader, "PK1", InvalidLimits)
     ),
 


### PR DESCRIPTION
We handle the error from server already. Additional checking of limits for read key requests does not add robustness. On the contrary, checking that read limits have correct shard against the cached stream shard map introduces flakiness:
* Client reads with invalid limits
* Limits are considered correct according to the cached shard map
* Client gets server error
* Client resets/updates limits
* Client reads again with correct shard in limits
* But shard map is still cached, so the correct limits are considered invalid
* Clients resets limits again
* ...